### PR TITLE
Reload nginx after cert update

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -3,7 +3,7 @@
 - hosts: tars
   gather_facts: no
   roles:
-    # - apt-update
+    - apt-update
     - tars
 
 - hosts: production

--- a/roles/tars-letsencrypt/tasks/main.yml
+++ b/roles/tars-letsencrypt/tasks/main.yml
@@ -21,7 +21,11 @@
 
 - name: Set cron to renew certs
   become: yes
-  cron: name="certbot renew" minute="10" hour="7" job="/user/bin/certbot-auto renew"
+  cron: name="certbot renew" minute="10" hour="7" day="2" job="/usr/bin/certbot-auto renew >> /var/log/letsencrypt-cron.log"
+
+- name: Set cron to reload nginx
+  become: yes
+  cron: name="nginx reload" minute="20" hour="7" day="2" job="/etc/init.d/nginx reload"
 
 # Replace nginx config with SSL flavour
 - name: Copy nginx config


### PR DESCRIPTION
Fixes the auto-renew cron and nginx update step for letsencrypt certs
